### PR TITLE
Switch conan repo source to Bincrafters and add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,9 +78,8 @@ compiler:
 install:
   - pip install --user conan
   - conan user
+  - conan remote add slidewave https://api.bintray.com/conan/slidewavellc/conan-libs
 script:
-  - pwd
-  - ls
   - conan install . -s build_type=Release --build=missing
   - cmake . -DCMAKE_BUILD_TYPE=Release 
   - cmake --build . --config Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,87 @@
 language: cpp
+sudo: required
+dist: trusty
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
+          packages:
+            - g++-4.9
+            - cmake-data
+            - cmake
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
+          packages:
+            - g++-5
+            - cmake-data
+            - cmake
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
+          packages:
+            - g++-6
+            - cmake-data
+            - cmake
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - george-edison55-precise-backports
+          packages:
+            - g++-7
+            - cmake-data
+            - cmake
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    # clang
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+            - george-edison55-precise-backports
+          packages:
+            - clang-3.8
+            - cmake-data
+            - cmake
+      env:
+        - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+    # OSX
+    - os: osx
+      osx_image: xcode8
+      env:
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+before_install:
+    - eval "${MATRIX_EVAL}"
 compiler:
   - gcc
 install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq g++-4.9
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
-  
-  pip install conan
-  conan user
-
-  mkdir build
-  conan install -s build_type=Release --build=missing
-  cd build
-  cmake ../ -DCMAKE_BUILD_TYPE=Release 
-  cmake --build . --config Release
+  - pip install conan
+  - conan user
+script:
+  - mkdir build
+  - conan install -s build_type=Release --build=missing
+  - cd build
+  - cmake ../ -DCMAKE_BUILD_TYPE=Release 
+  - cmake --build . --config Release
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ install:
   - pip install --user conan
   - conan user
   - conan remote add slidewave https://api.bintray.com/conan/slidewavellc/conan-libs
+  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 script:
   - conan install . -s build_type=Release --build=missing
   - cmake . -DCMAKE_BUILD_TYPE=Release 

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,9 @@ install:
   - pip install --user conan
   - conan user
 script:
-  - conan install ../ -s build_type=Release --build=missing
-  - cmake ../ -DCMAKE_BUILD_TYPE=Release 
-  - cmake --build ../ --config Release
+  - pwd
+  - ls
+  - conan install . -s build_type=Release --build=missing
+  - cmake . -DCMAKE_BUILD_TYPE=Release 
+  - cmake --build . --config Release
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+compiler:
+  - gcc
+install:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq g++-4.9
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+  
+  pip install conan
+  conan user
+
+  mkdir build
+  conan install -s build_type=Release --build=missing
+  cd build
+  cmake ../ -DCMAKE_BUILD_TYPE=Release 
+  cmake --build . --config Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_install:
 compiler:
   - gcc
 install:
-  - pip install -user conan
+  - pip install --user conan
   - conan user
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,7 @@ install:
   - pip install --user conan
   - conan user
 script:
-  - mkdir build
-  - conan install -s build_type=Release --build=missing
-  - cd build
+  - conan install ../ -s build_type=Release --build=missing
   - cmake ../ -DCMAKE_BUILD_TYPE=Release 
-  - cmake --build . --config Release
+  - cmake --build ../ --config Release
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,6 @@ compiler:
 install:
   - pip install --user conan
   - conan user
-  - conan remote add slidewave https://api.bintray.com/conan/slidewavellc/conan-libs
   - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 script:
   - conan install . -s build_type=Release --build=missing

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ install:
   cd build
   cmake ../ -DCMAKE_BUILD_TYPE=Release 
   cmake --build . --config Release
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_install:
 compiler:
   - gcc
 install:
-  - pip install conan
+  - pip install -user conan
   - conan user
 script:
   - mkdir build

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ mesh data to viewer software connected to the InWorldz grid
 - [CMake 3.8.2 or later](https://cmake.org/)
 - [Conan 0.28.1 or later](https://www.conan.io/)
 
-You will need to add the SlideWave LLC conan repository to obtain prebuilt packages:
+You will need to add the SlideWave LLC and bincrafters conan repositores to obtain prebuilt packages:
 ```
 conan remote add slidewave https://api.bintray.com/conan/slidewavellc/conan-libs
+conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 ```
 
 ### Sample cmake build command for Windows 64-bit

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ mesh data to viewer software connected to the InWorldz grid
 - [CMake 3.8.2 or later](https://cmake.org/)
 - [Conan 0.28.1 or later](https://www.conan.io/)
 
-You will need to add the SlideWave LLC and bincrafters conan repositores to obtain prebuilt packages:
+You will need to add the Bincrafters conan repositores to obtain prebuilt packages:
 ```
-conan remote add slidewave https://api.bintray.com/conan/slidewavellc/conan-libs
 conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 ```
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
 
 build_script:
   - cmd: mkdir build
-  - cmd: conan install -s build_type=Release -s arch=x86_64 -s compiler.runtime=MT --build=missing
+  - cmd: conan install . -s build_type=Release -s arch=x86_64 -s compiler.runtime=MT --build=missing
   - cmd: cd build
   - cmd: cmake ../ -DCMAKE_BUILD_TYPE=Release -G "Visual Studio 15 2017 Win64"
   - cmd: cmake --build . --config Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
   - cmd: conan user # Create the conan data directory
   - cmd: conan --version
   - cmd: conan remote add slidewave https://api.bintray.com/conan/slidewavellc/conan-libs
+  - cmd: conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 
 build_script:
   - cmd: mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ install:
   - cmd: pip.exe install conan --upgrade
   - cmd: conan user # Create the conan data directory
   - cmd: conan --version
-  - cmd: conan remote add slidewave https://api.bintray.com/conan/slidewavellc/conan-libs
   - cmd: conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
 
 build_script:

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -6,7 +6,6 @@ jsonformoderncpp/2.1.1@vthiery/stable
 zlib/1.2.11@conan/stable
 
 [options]
-Boost.Asio:shared=False
 libcurl:shared=False
 protobuf:shared=False
 zlib:shared=False

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,7 @@
 [requires]
 Boost.Asio/1.65.1@bincrafters/stable
 Boost.Format/1.65.1@bincrafters/stable
+Boost.Logic/1.65.1@bincrafters/stable
 Boost.Program_Options/1.65.1@bincrafters/stable
 libcurl/7.56.1@bincrafters/stable
 protobuf/3.5.1@bincrafters/stable

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,21 +1,14 @@
 [requires]
-Boost/1.64.0@slidewave/stable
+Boost.Asio/1.65.1@bincrafters/stable
+libcurl/7.56.1@bincrafters/stable
+protobuf/3.5.1@bincrafters/stable
 jsonformoderncpp/2.1.1@vthiery/stable
-libcurl/7.56.1@slidewave/stable
-Protobuf/3.5.1@slidewave/stable
 zlib/1.2.11@conan/stable
 
 [options]
-Boost:shared=False
-Boost:without_container=True
-Boost:without_context=True
-Boost:without_coroutine=True
-Boost:without_coroutine2=True
-Boost:without_graph=True
-Boost:without_type_erasure=True
-Boost:without_wave=True
+Boost.Asio:shared=False
 libcurl:shared=False
-Protobuf:shared=False
+protobuf:shared=False
 zlib:shared=False
 
 [generators]

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
 Boost.Asio/1.65.1@bincrafters/stable
+Boost.Format/1.65.1@bincrafters/stable
 Boost.Program_Options/1.65.1@bincrafters/stable
 libcurl/7.56.1@bincrafters/stable
 protobuf/3.5.1@bincrafters/stable

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
 Boost.Asio/1.65.1@bincrafters/stable
+Boost.Program_Options/1.65.1@bincrafters/stable
 libcurl/7.56.1@bincrafters/stable
 protobuf/3.5.1@bincrafters/stable
 jsonformoderncpp/2.1.1@vthiery/stable


### PR DESCRIPTION
Bincrafters provides a more modular Boost package and more prebuilts. This will reduce build time for many and lead to more compact executables.